### PR TITLE
Fix rdiscrowd 238 gui issues

### DIFF
--- a/pybossa/themes/default/static/sass/pybossa/_variables.scss
+++ b/pybossa/themes/default/static/sass/pybossa/_variables.scss
@@ -15,7 +15,7 @@ $gray:                   #95a5a6 !default; // #555
 $gray-light:             #b4bcc2 !default;   // #999
 $gray-lighter:           #F5F7F7 !default; // #eee
 
-$brand-primary:         #546E7A !default;
+$brand-primary:         #a9a9a9 !default;
 $brand-success:         #3AB0D5 !default;
 $brand-info:            #3498DB !default;
 $brand-warning:         #F39C12 !default;

--- a/pybossa/themes/default/templates/projects/base.html
+++ b/pybossa/themes/default/templates/projects/base.html
@@ -11,7 +11,7 @@
         {{ helper.render_project_local_nav(project, active_link, current_user, pro_features) }}
     </div>
     <!-- Project -->
-    <div class="col-sm-9 col-md-9" style="min-height:400px">
+    <div class="col-sm-9 col-md-9" style="min-height:400px;margin-top:30px;">
         <div class="row">
             <div class="col-sm-8 col-md-8">
                 <h1>{{project.name}}</h1>

--- a/pybossa/themes/default/templates/projects/presenter.html
+++ b/pybossa/themes/default/templates/projects/presenter.html
@@ -22,7 +22,7 @@
 
 <div class="container">
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-12" style="margin-top:30px;">
             <h1><a href="{{url_for('project.details', short_name=project.short_name)}}">{{ project.name }}</a>: {{ _('Contribute') }}</h1>
         </div>
     </div>


### PR DESCRIPTION
. add top margin for pages as the navbar width has been increased to fit gigwork brand logo
. change brand primary color to shade of gray as in current version
. set 30px margin for task presenter display because of nav bar width modified to accommodate gigwork brand logo